### PR TITLE
feat: Add toggleable valid move highlighting feature

### DIFF
--- a/shogi_game.css
+++ b/shogi_game.css
@@ -152,3 +152,8 @@ h1 {
 .selected-for-drop { /* Style for selected captured piece */
     box-shadow: 0 0 5px 2px yellow;
 }
+
+.square.valid-move-highlight {
+    background-color: rgba(46, 204, 113, 0.5); /* Semi-transparent light green */
+    cursor: pointer; /* Reinforce that it's a clickable target */
+}

--- a/shogi_game.html
+++ b/shogi_game.html
@@ -26,6 +26,9 @@
             <label style="margin-left: 15px;">
                 <input type="checkbox" id="single-player-checkbox"> Play vs AI (Gote)
             </label>
+            <label style="margin-left: 15px;">
+                <input type="checkbox" id="toggle-highlight-mode-checkbox" name="highlight-mode" checked> Show Valid Moves (候補手表示)
+            </label>
         </div>
     </div>
     <script src="shogi_game.js"></script>

--- a/shogi_game.js
+++ b/shogi_game.js
@@ -6,139 +6,93 @@ document.addEventListener('DOMContentLoaded', () => {
     const senteCapturedContainer = document.getElementById('sente-captured-pieces');
     const goteCapturedContainer = document.getElementById('gote-captured-pieces');
     const singlePlayerCheckbox = document.getElementById('single-player-checkbox');
+    const highlightModeCheckbox = document.getElementById('toggle-highlight-mode-checkbox');
 
-    // --- Piece Definitions ---
-    const PIECES = {
-        KING: '玉', ROOK: '飛', BISHOP: '角', GOLD: '金', SILVER: '銀',
-        KNIGHT: '桂', LANCE: '香', PAWN: '歩',
-        PROMOTED_ROOK: '龍', PROMOTED_BISHOP: '馬',
-        PROMOTED_SILVER: '全', PROMOTED_KNIGHT: '圭',
-        PROMOTED_LANCE: '杏', PROMOTED_PAWN: 'と',
-    };
-
-    // Maps for promotion and unpromotion using PIECES keys
-    const PROMOTION_MAP = { // Unpromoted Key -> Promoted Key
-        ROOK: 'PROMOTED_ROOK', BISHOP: 'PROMOTED_BISHOP',
-        SILVER: 'PROMOTED_SILVER', KNIGHT: 'PROMOTED_KNIGHT',
-        LANCE: 'PROMOTED_LANCE', PAWN: 'PROMOTED_PAWN',
-    };
-    const UNPROMOTED_MAP = { // Promoted Key -> Unpromoted Key
-        PROMOTED_ROOK: 'ROOK', PROMOTED_BISHOP: 'BISHOP',
-        PROMOTED_SILVER: 'SILVER', PROMOTED_KNIGHT: 'KNIGHT',
-        PROMOTED_LANCE: 'LANCE', PROMOTED_PAWN: 'PAWN',
-    };
-
-    const PROMOTABLE_PIECE_KEYS = Object.keys(PROMOTION_MAP); // ['ROOK', 'BISHOP', ...]
-
-    // Piece values for AI (using PIECES keys)
-    const PIECE_VALUES = {
-        PAWN: 1, LANCE: 3, KNIGHT: 3, SILVER: 5, GOLD: 6, BISHOP: 8, ROOK: 10, KING: 1000,
-        PROMOTED_PAWN: 4, PROMOTED_LANCE: 4, PROMOTED_KNIGHT: 4, PROMOTED_SILVER: 6,
-        PROMOTED_BISHOP: 10, PROMOTED_ROOK: 12,
-    };
+    // --- Piece Definitions --- (Same as before)
+    const PIECES = { KING: '玉', ROOK: '飛', BISHOP: '角', GOLD: '金', SILVER: '銀', KNIGHT: '桂', LANCE: '香', PAWN: '歩', PROMOTED_ROOK: '龍', PROMOTED_BISHOP: '馬', PROMOTED_SILVER: '全', PROMOTED_KNIGHT: '圭', PROMOTED_LANCE: '杏', PROMOTED_PAWN: 'と',};
+    const PROMOTION_MAP = { ROOK: 'PROMOTED_ROOK', BISHOP: 'PROMOTED_BISHOP', SILVER: 'PROMOTED_SILVER', KNIGHT: 'PROMOTED_KNIGHT', LANCE: 'PROMOTED_LANCE', PAWN: 'PROMOTED_PAWN',};
+    const UNPROMOTED_MAP = { PROMOTED_ROOK: 'ROOK', PROMOTED_BISHOP: 'BISHOP', PROMOTED_SILVER: 'SILVER', PROMOTED_KNIGHT: 'KNIGHT', PROMOTED_LANCE: 'LANCE', PROMOTED_PAWN: 'PAWN',};
+    const PROMOTABLE_PIECE_KEYS = Object.keys(PROMOTION_MAP);
+    const PIECE_VALUES = { PAWN: 1, LANCE: 3, KNIGHT: 3, SILVER: 5, GOLD: 6, BISHOP: 8, ROOK: 10, KING: 1000, PROMOTED_PAWN: 4, PROMOTED_LANCE: 4, PROMOTED_KNIGHT: 4, PROMOTED_SILVER: 6, PROMOTED_BISHOP: 10, PROMOTED_ROOK: 12,};
 
     const PLAYER_SENTE = 'sente'; const PLAYER_GOTE = 'gote';
     const SENTE_PROMOTION_ZONE = [0, 1, 2]; const GOTE_PROMOTION_ZONE = [6, 7, 8];
     let board = []; let currentPlayer = PLAYER_SENTE; let selectedPiece = null;
     let selectedPieceForDrop = null; let senteCapturedPieces = []; let goteCapturedPieces = [];
     let isGameOver = false; let gameStatusMessage = ""; let isSinglePlayerMode = false; let isAiThinking = false;
+    let isHighlightModeEnabled = true; // Initialized below from checkbox
 
+    // --- Utility Functions ---
     function deepCopyBoard(b) { return b.map(r => r.map(p => (p ? { ...p } : null))); }
     function getKingPosition(player, currentBoard) { for (let r = 0; r < 9; r++) for (let c = 0; c < 9; c++) { const p = currentBoard[r][c]; if (p && p.type === 'KING' && p.player === player) return { r, c }; } return null; }
+    function getSquareElement(row, col) { return document.querySelector(`.square[data-row='${row}'][data-col='${col}']`); }
 
-    // --- Piece Movement Logic (keyed by PIECES keys e.g., 'PAWN', 'GOLD', 'PROMOTED_ROOK') ---
-    const pieceMoveLogic = {
-        PAWN:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c]];},
-        LANCE:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;const m=[];for(let i=1;i<9;i++){const nR=r+dir*i;if(nR<0||nR>8)break;const tP=b[nR][c];if(tP){if(tP.player!==player)m.push([nR,c]);break;}m.push([nR,c]);}return m;},
-        KNIGHT:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir*2,c-1],[r+dir*2,c+1]];},
-        SILVER:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c],[r+dir,c-1],[r+dir,c+1],[r-dir,c-1],[r-dir,c+1]];},
-        GOLD:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c],[r-dir,c],[r,c-1],[r,c+1],[r+dir,c-1],[r+dir,c+1]].filter(([nr,nc])=>!(nr===r-dir&&(nc===c-1||nc===c+1)));},
-        BISHOP:(r,c,player,p,b)=>{const m=[];const dirs=[[-1,-1],[-1,1],[1,-1],[1,1]];for(const[dr,dc]of dirs){for(let i=1;i<9;i++){const nR=r+dr*i;const nC=c+dc*i;if(nR<0||nR>8||nC<0||nC>8)break;const tP=b[nR][nC];if(tP){if(tP.player!==player)m.push([nR,nC]);break;}m.push([nR,nC]);}}/* Promoted part handled by PROMOTED_BISHOP logic */ return m;},
-        ROOK:(r,c,player,p,b)=>{const m=[];const dirs=[[-1,0],[1,0],[0,-1],[0,1]];for(const[dr,dc]of dirs){for(let i=1;i<9;i++){const nR=r+dr*i;const nC=c+dc*i;if(nR<0||nR>8||nC<0||nC>8)break;const tP=b[nR][nC];if(tP){if(tP.player!==player)m.push([nR,nC]);break;}m.push([nR,nC]);}}/* Promoted part handled by PROMOTED_ROOK logic */ return m;},
-        KING:(r,c,player,p,b)=>{return[[r-1,c-1],[r-1,c],[r-1,c+1],[r,c-1],[r,c+1],[r+1,c-1],[r+1,c],[r+1,c+1]];},
-        // Promoted pieces
-        PROMOTED_ROOK:(r,c,player,p,b)=>{let m=pieceMoveLogic.ROOK(r,c,player,p,b);m.push(...[[r+1,c+1],[r+1,c-1],[r-1,c+1],[r-1,c-1]]);return m;},
-        PROMOTED_BISHOP:(r,c,player,p,b)=>{let m=pieceMoveLogic.BISHOP(r,c,player,p,b);m.push(...[[r+1,c],[r-1,c],[r,c+1],[r,c-1]]);return m;},
-    };
-    // Gold General moves for most promoted pieces
-    pieceMoveLogic.PROMOTED_PAWN = pieceMoveLogic.GOLD; pieceMoveLogic.PROMOTED_LANCE = pieceMoveLogic.GOLD;
-    pieceMoveLogic.PROMOTED_KNIGHT = pieceMoveLogic.GOLD; pieceMoveLogic.PROMOTED_SILVER = pieceMoveLogic.GOLD;
+    // --- Piece Movement Logic --- (Same as before, keyed by PIECES keys)
+    const pieceMoveLogic = { PAWN:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c]];}, LANCE:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;const m=[];for(let i=1;i<9;i++){const nR=r+dir*i;if(nR<0||nR>8)break;const tP=b[nR][c];if(tP){if(tP.player!==player)m.push([nR,c]);break;}m.push([nR,c]);}return m;}, KNIGHT:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir*2,c-1],[r+dir*2,c+1]];}, SILVER:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c],[r+dir,c-1],[r+dir,c+1],[r-dir,c-1],[r-dir,c+1]];}, GOLD:(r,c,player,p,b)=>{const dir=player===PLAYER_SENTE?-1:1;return[[r+dir,c],[r-dir,c],[r,c-1],[r,c+1],[r+dir,c-1],[r+dir,c+1]].filter(([nr,nc])=>!(nr===r-dir&&(nc===c-1||nc===c+1)));}, BISHOP:(r,c,player,p,b)=>{const m=[];const dirs=[[-1,-1],[-1,1],[1,-1],[1,1]];for(const[dr,dc]of dirs){for(let i=1;i<9;i++){const nR=r+dr*i;const nC=c+dc*i;if(nR<0||nR>8||nC<0||nC>8)break;const tP=b[nR][nC];if(tP){if(tP.player!==player)m.push([nR,nC]);break;}m.push([nR,nC]);}}return m;}, ROOK:(r,c,player,p,b)=>{const m=[];const dirs=[[-1,0],[1,0],[0,-1],[0,1]];for(const[dr,dc]of dirs){for(let i=1;i<9;i++){const nR=r+dr*i;const nC=c+dc*i;if(nR<0||nR>8||nC<0||nC>8)break;const tP=b[nR][nC];if(tP){if(tP.player!==player)m.push([nR,nC]);break;}m.push([nR,nC]);}}return m;}, KING:(r,c,player,p,b)=>{return[[r-1,c-1],[r-1,c],[r-1,c+1],[r,c-1],[r,c+1],[r+1,c-1],[r+1,c],[r+1,c+1]];}, PROMOTED_ROOK:(r,c,player,p,b)=>{let m=pieceMoveLogic.ROOK(r,c,player,p,b);m.push(...[[r+1,c+1],[r+1,c-1],[r-1,c+1],[r-1,c-1]]);return m;}, PROMOTED_BISHOP:(r,c,player,p,b)=>{let m=pieceMoveLogic.BISHOP(r,c,player,p,b);m.push(...[[r+1,c],[r-1,c],[r,c+1],[r,c-1]]);return m;},};
+    pieceMoveLogic.PROMOTED_PAWN = pieceMoveLogic.GOLD; pieceMoveLogic.PROMOTED_LANCE = pieceMoveLogic.GOLD; pieceMoveLogic.PROMOTED_KNIGHT = pieceMoveLogic.GOLD; pieceMoveLogic.PROMOTED_SILVER = pieceMoveLogic.GOLD;
+    function getValidMoves(pc,r,c,cB){let k=pc.type;if(pc.promoted&&PROMOTION_MAP[pc.type]){k=PROMOTION_MAP[pc.type];}const fn=pieceMoveLogic[k];if(!fn)return[];return fn(r,c,pc.player,pc,cB).filter(([tR,tC])=>tR>=0&&tR<9&&tC>=0&&tC<9&&(!cB[tR][tC]||cB[tR][tC].player!==pc.player));}
 
-    function getValidMoves(pc,r,c,cB){ // pc.type is a key like 'PAWN'
-        let typeKeyForLogic = pc.type;
-        if(pc.promoted && PROMOTION_MAP[pc.type]) {
-            typeKeyForLogic = PROMOTION_MAP[pc.type]; // e.g., 'PROMOTED_PAWN'
-        }
-        const moveFn = pieceMoveLogic[typeKeyForLogic];
-        if(!moveFn) return [];
-        return moveFn(r,c,pc.player,pc,cB).filter(([tR,tC])=>tR>=0&&tR<9&&tC>=0&&tC<9&&(!cB[tR][tC]||cB[tR][tC].player!==pc.player));
-    }
-
+    // --- Check, Checkmate, Promotion, Drop Validation --- (Same as before)
     function isInCheck(player,currentBoard){const kingPos=getKingPosition(player,currentBoard);if(!kingPos)return false;const opp=player===PLAYER_SENTE?PLAYER_GOTE:PLAYER_SENTE;for(let r=0;r<9;r++){for(let c=0;c<9;c++){const p=currentBoard[r][c];if(p&&p.player===opp){const moves=getValidMoves(p,r,c,currentBoard);if(moves.some(([mr,mc])=>mr===kingPos.r&&mc===kingPos.c))return true;}}}return false;}
     function isCheckmate(player,currentBoard){if(!isInCheck(player,currentBoard))return false;for(let r=0;r<9;r++){for(let c=0;c<9;c++){const p=currentBoard[r][c];if(p&&p.player===player){const moves=getValidMoves(p,r,c,currentBoard);for(const[mr,mc]of moves){const tB=deepCopyBoard(currentBoard);let simPiece={...p};tB[mr][mc]=simPiece;tB[r][c]=null;if(canPromote(simPiece,mr,r,player)&&(mustPromote(simPiece,mr,player)||true)){simPiece.promoted=true;}if(!isInCheck(player,tB))return false;}}}}const captured=player===PLAYER_SENTE?senteCapturedPieces:goteCapturedPieces;for(const cp of captured){for(let dr=0;dr<9;dr++){for(let dc=0;dc<9;dc++){if(isValidDrop(cp.type,dr,dc,player,currentBoard)){const tB=deepCopyBoard(currentBoard);tB[dr][dc]={type:cp.type,player:player,promoted:false};if(!isInCheck(player,tB))return false;}}}}return true;}
+    function isPromotionZone(row,player){return player===PLAYER_SENTE?SENTE_PROMOTION_ZONE.includes(row):GOTE_PROMOTION_ZONE.includes(row);}
+    function canPromote(pc,toR,fromR,plyr){if(pc.promoted||!PROMOTABLE_PIECE_KEYS.includes(pc.type))return false;return isPromotionZone(toR,plyr)||isPromotionZone(fromR,plyr);}
+    function mustPromote(pc,toR,plyr){if(pc.type==='PAWN'||pc.type==='LANCE')return plyr===PLAYER_SENTE?toR===0:toR===8;if(pc.type==='KNIGHT')return plyr===PLAYER_SENTE?(toR===0||toR===1):(toR===7||toR===8);return false;}
+    function isValidDrop(key,toR,toC,player,cB){if(cB[toR][toC])return false;if((key==='PAWN'||key==='LANCE')&&((player===PLAYER_SENTE&&toR===0)||(player===PLAYER_GOTE&&toR===8)))return false;if(key==='KNIGHT'&&((player===PLAYER_SENTE&&(toR===0||toR===1))||(player===PLAYER_GOTE&&(toR===7||toR===8))))return false;if(key==='PAWN'){for(let r=0;r<9;r++){const ep=cB[r][toC];if(ep&&ep.player===player&&ep.type==='PAWN'&&!ep.promoted)return false;}}return true;}
 
-    function initializeBoard(){isSinglePlayerMode=singlePlayerCheckbox.checked;board=Array(9).fill(null).map(()=>Array(9).fill(null));senteCapturedPieces=[];goteCapturedPieces=[];isGameOver=false;gameStatusMessage="";isAiThinking=false;const place=(k,p,r,c)=>{board[r][c]={type:k,player:p,promoted:false};};place('LANCE',PLAYER_GOTE,0,0);place('KNIGHT',PLAYER_GOTE,0,1);place('SILVER',PLAYER_GOTE,0,2);place('GOLD',PLAYER_GOTE,0,3);place('KING',PLAYER_GOTE,0,4);place('GOLD',PLAYER_GOTE,0,5);place('SILVER',PLAYER_GOTE,0,6);place('KNIGHT',PLAYER_GOTE,0,7);place('LANCE',PLAYER_GOTE,0,8);place('ROOK',PLAYER_GOTE,1,1);place('BISHOP',PLAYER_GOTE,1,7);for(let i=0;i<9;i++)place('PAWN',PLAYER_GOTE,2,i);for(let i=0;i<9;i++)place('PAWN',PLAYER_SENTE,6,i);place('BISHOP',PLAYER_SENTE,7,1);place('ROOK',PLAYER_SENTE,7,7);place('LANCE',PLAYER_SENTE,8,0);place('KNIGHT',PLAYER_SENTE,8,1);place('SILVER',PLAYER_SENTE,8,2);place('GOLD',PLAYER_SENTE,8,3);place('KING',PLAYER_SENTE,8,4);place('GOLD',PLAYER_SENTE,8,5);place('SILVER',PLAYER_SENTE,8,6);place('KNIGHT',PLAYER_SENTE,8,7);place('LANCE',PLAYER_SENTE,8,8);selectedPiece=null;selectedPieceForDrop=null;currentPlayer=PLAYER_SENTE;updatePlayerTurnDisplay();renderBoard();}
+    // --- Valid Move Highlighting ---
+    function clearAllValidMoveHighlights() {
+        document.querySelectorAll('.square.valid-move-highlight').forEach(sq => {
+            sq.classList.remove('valid-move-highlight');
+        });
+    }
 
-    function renderBoard() {
-        boardContainer.innerHTML = '';
-        for (let r = 0; r < 9; r++) {
-            for (let c = 0; c < 9; c++) {
-                const square = document.createElement('div');
-                square.classList.add('square');
-                square.dataset.row = r; square.dataset.col = c;
-                const pieceData = board[r][c]; // e.g. { type: 'PAWN', player: 'sente', promoted: false }
-                if (pieceData) {
-                    const pieceElement = document.createElement('div');
-                    pieceElement.classList.add('piece', pieceData.player);
+    function showValidMoveHighlights(piece, fromRow, fromCol) {
+        clearAllValidMoveHighlights();
+        if (!isHighlightModeEnabled || !piece) return;
 
-                    let displaySymbolKey = pieceData.type; // 'PAWN'
-                    if (pieceData.promoted && PROMOTION_MAP[pieceData.type]) {
-                        displaySymbolKey = PROMOTION_MAP[pieceData.type]; // 'PROMOTED_PAWN'
-                    }
-                    pieceElement.textContent = PIECES[displaySymbolKey]; // PIECES['PROMOTED_PAWN'] -> 'と'
+        const validMoves = getValidMoves(piece, fromRow, fromCol, board);
+        validMoves.forEach(([r, c]) => {
+            const squareEl = getSquareElement(r, c);
+            if (squareEl) {
+                squareEl.classList.add('valid-move-highlight');
+            }
+        });
+    }
 
-                    if (pieceData.type === 'KING' && isInCheck(pieceData.player, board)) {
-                        pieceElement.classList.add('in-check');
-                    }
-                    square.appendChild(pieceElement);
-                }
-                boardContainer.appendChild(square);
+    // --- Game Initialization & Rendering ---
+    function initializeBoard(){isSinglePlayerMode=singlePlayerCheckbox.checked;isHighlightModeEnabled=highlightModeCheckbox.checked;board=Array(9).fill(null).map(()=>Array(9).fill(null));senteCapturedPieces=[];goteCapturedPieces=[];isGameOver=false;gameStatusMessage="";isAiThinking=false;const place=(k,p,r,c)=>{board[r][c]={type:k,player:p,promoted:false};};place('LANCE',PLAYER_GOTE,0,0);place('KNIGHT',PLAYER_GOTE,0,1);place('SILVER',PLAYER_GOTE,0,2);place('GOLD',PLAYER_GOTE,0,3);place('KING',PLAYER_GOTE,0,4);place('GOLD',PLAYER_GOTE,0,5);place('SILVER',PLAYER_GOTE,0,6);place('KNIGHT',PLAYER_GOTE,0,7);place('LANCE',PLAYER_GOTE,0,8);place('ROOK',PLAYER_GOTE,1,1);place('BISHOP',PLAYER_GOTE,1,7);for(let i=0;i<9;i++)place('PAWN',PLAYER_GOTE,2,i);for(let i=0;i<9;i++)place('PAWN',PLAYER_SENTE,6,i);place('BISHOP',PLAYER_SENTE,7,1);place('ROOK',PLAYER_SENTE,7,7);place('LANCE',PLAYER_SENTE,8,0);place('KNIGHT',PLAYER_SENTE,8,1);place('SILVER',PLAYER_SENTE,8,2);place('GOLD',PLAYER_SENTE,8,3);place('KING',PLAYER_SENTE,8,4);place('GOLD',PLAYER_SENTE,8,5);place('SILVER',PLAYER_SENTE,8,6);place('KNIGHT',PLAYER_SENTE,8,7);place('LANCE',PLAYER_SENTE,8,8);selectedPiece=null;selectedPieceForDrop=null;currentPlayer=PLAYER_SENTE;clearAllValidMoveHighlights();updatePlayerTurnDisplay();renderBoard();}
+    function renderBoard(){boardContainer.innerHTML='';for(let r=0;r<9;r++){for(let c=0;c<9;c++){const sq=document.createElement('div');sq.classList.add('square');sq.dataset.row=r;sq.dataset.col=c;const pD=board[r][c];if(pD){const pE=document.createElement('div');pE.classList.add('piece',pD.player);let dSK=pD.type;if(pD.promoted&&PROMOTION_MAP[pD.type]){dSK=PROMOTION_MAP[pD.type];}pE.textContent=PIECES[dSK];if(pD.type==='KING'&&isInCheck(pD.player,board))pE.classList.add('in-check');sq.appendChild(pE);}if(selectedPiece&&selectedPiece.fromRow===r&&selectedPiece.fromCol===c)sq.classList.add('selected-piece-square'); /* Optional: highlight selected piece's square */ boardContainer.appendChild(sq);}}addSquareClickListeners();renderCapturedPieces();updatePlayerTurnDisplay();}
+    function renderCapturedPieces(){const setup=(cont,list,owner)=>{if(!cont)return;cont.innerHTML='';const counts={};list.forEach(p=>counts[p.type]=(counts[p.type]||0)+1);Object.entries(counts).forEach(([key,count])=>{const disp=document.createElement('div');disp.classList.add('captured-piece-display');if(selectedPieceForDrop&&selectedPieceForDrop.type===key&&currentPlayer===owner)disp.classList.add('selected-for-drop');disp.textContent=`${PIECES[key]} (${count})`;disp.dataset.pieceTypeKey=key;if(currentPlayer===owner&&!isGameOver&&!(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE))disp.addEventListener('click',()=>handleCapturedPieceClick(key,owner));cont.appendChild(disp);});};setup(senteCapturedContainer,senteCapturedPieces,PLAYER_SENTE);setup(goteCapturedContainer,goteCapturedPieces,PLAYER_GOTE);}
+    function updatePlayerTurnDisplay(){let turnText=isGameOver?gameStatusMessage:`${currentPlayer===PLAYER_SENTE?"Sente's":"Gote's"} Turn`;if(isAiThinking)turnText="AI is thinking...";else if(selectedPieceForDrop&&!isGameOver)turnText+=` (Dropping ${PIECES[selectedPieceForDrop.type]})`;if(gameStatusMessage&&!isGameOver&&isInCheck(currentPlayer,board)&&!isAiThinking)turnText+=` - ${gameStatusMessage}`;playerTurnElement.textContent=turnText;}
+
+    // --- AI Logic --- (Same as before)
+    function makeAiMove(){isAiThinking=true;updatePlayerTurnDisplay();setTimeout(()=>{let allLegalActions=[];for(let r=0;r<9;r++){for(let c=0;c<9;c++){const piece=board[r][c];if(piece&&piece.player===PLAYER_GOTE){const moves=getValidMoves(piece,r,c,board);for(const[mr,mc]of moves){const tempBoard=deepCopyBoard(board);const pieceCopy={...piece};const capturedPieceOnTarget=tempBoard[mr][mc];tempBoard[mr][mc]=pieceCopy;tempBoard[r][c]=null;let isPromotion=false;if(canPromote(pieceCopy,mr,r,PLAYER_GOTE)&&!pieceCopy.promoted){if(mustPromote(pieceCopy,mr,PLAYER_GOTE)||true){isPromotion=true;}}const pieceForCheckTest={...pieceCopy};if(isPromotion)pieceForCheckTest.promoted=true;tempBoard[mr][mc]=pieceForCheckTest;if(!isInCheck(PLAYER_GOTE,tempBoard)){let score=0;if(capturedPieceOnTarget)score+=(PIECE_VALUES[capturedPieceOnTarget.type]||1)*10;if(isPromotion)score+=2;if(isInCheck(PLAYER_SENTE,tempBoard))score+=50;allLegalActions.push({action:'move',piece,fromR:r,fromC:c,toR:mr,toC:mc,promotion:isPromotion,score});}}}}}for(const capPiece of goteCapturedPieces){for(let dr=0;dr<9;dr++){for(let dc=0;dc<9;dc++){if(isValidDrop(capPiece.type,dr,dc,PLAYER_GOTE,board)){const tempBoard=deepCopyBoard(board);tempBoard[dr][dc]={type:capPiece.type,player:PLAYER_GOTE,promoted:false};if(!isInCheck(PLAYER_GOTE,tempBoard)){let score=1;if(isInCheck(PLAYER_SENTE,tempBoard))score+=50;allLegalActions.push({action:'drop',pieceTypeKey:capPiece.type,toR:dr,toC:dc,score});}}}}}if(allLegalActions.length===0){console.log("AI has no legal moves!");isAiThinking=false;updatePlayerTurnDisplay();return;}allLegalActions.sort((a,b)=>b.score-a.score);const bestScore=allLegalActions[0].score;const bestMoves=allLegalActions.filter(m=>m.score===bestScore);const chosenAction=bestMoves[Math.floor(Math.random()*bestMoves.length)];console.log("AI Chose: ",chosenAction);if(chosenAction.action==='move'){const pieceToMove=board[chosenAction.fromR][chosenAction.fromC];const targetPiece=board[chosenAction.toR][chosenAction.toC];if(targetPiece){let unpromotedTypeKey=UNPROMOTED_MAP[targetPiece.type]||targetPiece.type;goteCapturedPieces.push({type:unpromotedTypeKey,originalPlayer:targetPiece.player});}board[chosenAction.fromR][chosenAction.fromC]=null;pieceToMove.promoted=chosenAction.promotion;board[chosenAction.toR][chosenAction.toC]=pieceToMove;}else if(chosenAction.action==='drop'){board[chosenAction.toR][chosenAction.toC]={type:chosenAction.pieceTypeKey,player:PLAYER_GOTE,promoted:false};const dropIdx=goteCapturedPieces.findIndex(p=>p.type===chosenAction.pieceTypeKey);if(dropIdx>-1)goteCapturedPieces.splice(dropIdx,1);}isAiThinking=false;switchPlayerAndCheckGameEnd();},500);}
+
+    // --- Click Handlers & Game Flow ---
+    function handleCapturedPieceClick(typeKey,owner){if(isGameOver||currentPlayer!==owner||(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE))return; clearAllValidMoveHighlights(); if(selectedPieceForDrop&&selectedPieceForDrop.type===typeKey){selectedPieceForDrop=null;}else{selectedPieceForDrop={type:typeKey,originalPlayer:owner};selectedPiece=null;}renderCapturedPieces();updatePlayerTurnDisplay();}
+    function handleSquareClick(event){if(isGameOver||isAiThinking||(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE&&!isAiThinking))return;const clickedSq=event.target.closest('.square');if(!clickedSq)return;const toR=parseInt(clickedSq.dataset.row);const toC=parseInt(clickedSq.dataset.col);if(selectedPieceForDrop){const pieceToDropKey=selectedPieceForDrop.type;if(board[toR][toC]){if(board[toR][toC].player===currentPlayer){selectedPiece={piece:board[toR][toC],fromRow:toR,fromCol:toC};selectedPieceForDrop=null;showValidMoveHighlights(selectedPiece.piece,selectedPiece.fromRow,selectedPiece.fromCol);renderCapturedPieces();updatePlayerTurnDisplay();console.log(`Switched to move mode. Selected ${PIECES[selectedPiece.piece.type]}`);}else{console.log("Cannot drop onto an occupied square.");}return;}if(isValidDrop(pieceToDropKey,toR,toC,currentPlayer,board)){const tempBoard=deepCopyBoard(board);tempBoard[toR][toC]={type:pieceToDropKey,player:currentPlayer,promoted:false};if(isInCheck(currentPlayer,tempBoard)){console.log("Illegal drop: cannot put own king in check.");gameStatusMessage="Illegal: Puts King in Check";updatePlayerTurnDisplay();setTimeout(()=>{gameStatusMessage="";updatePlayerTurnDisplay();},2000);return;}board[toR][toC]=tempBoard[toR][toC];const hand=currentPlayer===PLAYER_SENTE?senteCapturedPieces:goteCapturedPieces;const idx=hand.findIndex(p=>p.type===pieceToDropKey);if(idx>-1)hand.splice(idx,1);console.log(`${currentPlayer} dropped ${PIECES[pieceToDropKey]} at (${toR},${toC})`);selectedPieceForDrop=null;clearAllValidMoveHighlights();switchPlayerAndCheckGameEnd();}else{console.log(`Invalid drop for ${PIECES[pieceToDropKey]} at (${toR},${toC})`);}}else if(selectedPiece){const{piece,fromRow,fromCol}=selectedPiece;if(fromRow===toR&&fromCol===toC){selectedPiece=null;clearAllValidMoveHighlights();console.log("Deselected.");return;}const targetPiece=board[toR][toC];if(targetPiece&&targetPiece.player===currentPlayer){selectedPiece={piece:targetPiece,fromRow:toR,fromCol:toC};showValidMoveHighlights(selectedPiece.piece,selectedPiece.fromRow,selectedPiece.fromCol);console.log(`Reselected: ${PIECES[targetPiece.type]}`);return;}const validMoves=getValidMoves(piece,fromRow,fromCol,board);if(validMoves.some(([r,c])=>r===toR&&c===toC)){const tempBoard=deepCopyBoard(board);let pieceToMoveCopy={...piece};if(targetPiece&&targetPiece.player!==currentPlayer){}tempBoard[toR][toC]=pieceToMoveCopy;tempBoard[fromRow][fromCol]=null;let potentialPromotion=false;if(canPromote(pieceToMoveCopy,toR,fromRow,currentPlayer)){if(mustPromote(pieceToMoveCopy,toR,currentPlayer)||window.confirm(`Promote ${PIECES[pieceToMoveCopy.type]} to ${PIECES[PROMOTION_MAP[pieceToMoveCopy.type]] || PIECES[pieceToMoveCopy.type]}?`)){potentialPromotion=true;pieceToMoveCopy.promoted=true;}}tempBoard[toR][toC]=pieceToMoveCopy;if(isInCheck(currentPlayer,tempBoard)){console.log("Illegal move: cannot put own king in check.");gameStatusMessage="Illegal: Puts King in Check";updatePlayerTurnDisplay();setTimeout(()=>{gameStatusMessage="";updatePlayerTurnDisplay();},2000);return;}let actualMovedPiece={...piece};if(targetPiece&&targetPiece.player!==currentPlayer){const captured=targetPiece;let unpromotedTypeKey=UNPROMOTED_MAP[captured.type]||captured.type;(currentPlayer===PLAYER_SENTE?senteCapturedPieces:goteCapturedPieces).push({type:unpromotedTypeKey,originalPlayer:captured.player});console.log(`${currentPlayer} captured ${PIECES[captured.type]}`);}board[fromRow][fromCol]=null;if(canPromote(actualMovedPiece,toR,fromRow,currentPlayer)){if(mustPromote(actualMovedPiece,toR,currentPlayer)||pieceToMoveCopy.promoted){actualMovedPiece.promoted=true;console.log(`Piece ${PIECES[piece.type]} promoted.`);}}board[toR][toC]=actualMovedPiece;console.log(`${currentPlayer} moved ${PIECES[piece.type]} from (${fromRow},${fromCol}) to (${toR},${toC})`);selectedPiece=null;clearAllValidMoveHighlights();switchPlayerAndCheckGameEnd();}else{console.log(`Invalid move for ${PIECES[piece.type]}`);}}else{const pieceOnSq=board[toR][toC];if(pieceOnSq&&pieceOnSq.player===currentPlayer){selectedPiece={piece:pieceOnSq,fromRow:toR,fromCol:toC};selectedPieceForDrop=null;showValidMoveHighlights(selectedPiece.piece,selectedPiece.fromRow,selectedPiece.fromCol);console.log(`Selected: ${PIECES[pieceOnSq.type]} at (${toR}, ${toC})`);renderCapturedPieces();updatePlayerTurnDisplay();}else if(pieceOnSq){console.log("Opponent's piece.");}else{clearAllValidMoveHighlights(); console.log("Empty square.");}}}
+    function switchPlayerAndCheckGameEnd(){const prevPlayer=currentPlayer;currentPlayer=currentPlayer===PLAYER_SENTE?PLAYER_GOTE:PLAYER_SENTE;gameStatusMessage="";if(isCheckmate(currentPlayer,board)){gameStatusMessage=`Checkmate! ${prevPlayer} wins!`;isGameOver=true;console.log(gameStatusMessage);}else if(isInCheck(currentPlayer,board)){gameStatusMessage="Check!";console.log("Player is in Check!");}clearAllValidMoveHighlights(); renderBoard();if(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE&&!isGameOver){makeAiMove();}}
+    function addSquareClickListeners(){const squares=document.querySelectorAll('.square');squares.forEach(sq=>{sq.removeEventListener('click',handleSquareClick);sq.addEventListener('click',handleSquareClick);});}
+
+    // Event Listeners for Controls
+    newGameButton.addEventListener('click',startGame);
+    singlePlayerCheckbox.addEventListener('change',startGame);
+    highlightModeCheckbox.addEventListener('change', () => {
+        isHighlightModeEnabled = highlightModeCheckbox.checked;
+        if (!isHighlightModeEnabled) {
+            clearAllValidMoveHighlights();
+        } else {
+            // If a piece is already selected, show its highlights
+            if (selectedPiece) {
+                showValidMoveHighlights(selectedPiece.piece, selectedPiece.fromRow, selectedPiece.fromCol);
             }
         }
-        addSquareClickListeners(); renderCapturedPieces(); updatePlayerTurnDisplay();
-    }
+    });
 
-    function renderCapturedPieces() {
-        const setup = (cont, list, owner) => { // list contains {type: 'PAWN', originalPlayer: ...}
-            if(!cont) return; cont.innerHTML = '';
-            const counts = {}; list.forEach(p => counts[p.type] = (counts[p.type] || 0) + 1);
-            Object.entries(counts).forEach(([typeKey, count]) => { // typeKey is 'PAWN'
-                const disp = document.createElement('div');
-                disp.classList.add('captured-piece-display');
-                if(selectedPieceForDrop && selectedPieceForDrop.type === typeKey && currentPlayer === owner) disp.classList.add('selected-for-drop');
-
-                disp.textContent = `${PIECES[typeKey]} (${count})`; // PIECES['PAWN'] -> '歩'
-
-                disp.dataset.pieceTypeKey = typeKey;
-                if(currentPlayer === owner && !isGameOver && !(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE)) disp.addEventListener('click',()=>handleCapturedPieceClick(typeKey, owner));
-                cont.appendChild(disp);
-            });
-        };
-        setup(senteCapturedContainer, senteCapturedPieces, PLAYER_SENTE);
-        setup(goteCapturedContainer, goteCapturedPieces, PLAYER_GOTE);
-    }
-
-    function updatePlayerTurnDisplay(){let turnText=isGameOver?gameStatusMessage:`${currentPlayer===PLAYER_SENTE?"Sente's":"Gote's"} Turn`;if(isAiThinking)turnText="AI is thinking...";else if(selectedPieceForDrop&&!isGameOver)turnText+=` (Dropping ${PIECES[selectedPieceForDrop.type]})`;if(gameStatusMessage&&!isGameOver&&isInCheck(currentPlayer,board)&&!isAiThinking)turnText+=` - ${gameStatusMessage}`;playerTurnElement.textContent=turnText;}
-    function isPromotionZone(row,player){return player===PLAYER_SENTE?SENTE_PROMOTION_ZONE.includes(row):GOTE_PROMOTION_ZONE.includes(row);}
-    function canPromote(pc,toR,fromR,plyr){if(pc.promoted||!PROMOTABLE_PIECE_KEYS.includes(pc.type))return false;return isPromotionZone(toR,plyr)||isPromotionZone(fromR,plyr);} // pc.type is key 'PAWN'
-    function mustPromote(pc,toR,plyr){if(pc.type==='PAWN'||pc.type==='LANCE')return plyr===PLAYER_SENTE?toR===0:toR===8;if(pc.type==='KNIGHT')return plyr===PLAYER_SENTE?(toR===0||toR===1):(toR===7||toR===8);return false;}
-    function isValidDrop(pieceTypeKey,toR,toC,player,currentBoard){if(currentBoard[toR][toC])return false;if((pieceTypeKey==='PAWN'||pieceTypeKey==='LANCE')&&((player===PLAYER_SENTE&&toR===0)||(player===PLAYER_GOTE&&toR===8)))return false;if(pieceTypeKey==='KNIGHT'&&((player===PLAYER_SENTE&&(toR===0||toR===1))||(player===PLAYER_GOTE&&(toR===7||toR===8))))return false;if(pieceTypeKey==='PAWN'){for(let r=0;r<9;r++){const ep=currentBoard[r][toC];if(ep&&ep.player===player&&ep.type==='PAWN'&&!ep.promoted)return false;}}return true;}
-
-    function makeAiMove(){isAiThinking=true;updatePlayerTurnDisplay();setTimeout(()=>{let allLegalActions=[];for(let r=0;r<9;r++){for(let c=0;c<9;c++){const piece=board[r][c];if(piece&&piece.player===PLAYER_GOTE){const moves=getValidMoves(piece,r,c,board);for(const[mr,mc]of moves){const tempBoard=deepCopyBoard(board);const pieceCopy={...piece};const capturedPieceOnTarget=tempBoard[mr][mc];tempBoard[mr][mc]=pieceCopy;tempBoard[r][c]=null;let isPromotion=false;if(canPromote(pieceCopy,mr,r,PLAYER_GOTE)&&!pieceCopy.promoted){if(mustPromote(pieceCopy,mr,PLAYER_GOTE)||true){isPromotion=true;}}const pieceForCheckTest={...pieceCopy};if(isPromotion)pieceForCheckTest.promoted=true;tempBoard[mr][mc]=pieceForCheckTest;if(!isInCheck(PLAYER_GOTE,tempBoard)){let score=0;if(capturedPieceOnTarget)score+=(PIECE_VALUES[capturedPieceOnTarget.type]||1)*10;if(isPromotion)score+=2;if(isInCheck(PLAYER_SENTE,tempBoard))score+=50;allLegalActions.push({action:'move',piece,fromR:r,fromC:c,toR:mr,toC:mc,promotion:isPromotion,score});}}}}}for(const capPiece of goteCapturedPieces){for(let dr=0;dr<9;dr++){for(let dc=0;dc<9;dc++){if(isValidDrop(capPiece.type,dr,dc,PLAYER_GOTE,board)){const tempBoard=deepCopyBoard(board);tempBoard[dr][dc]={type:capPiece.type,player:PLAYER_GOTE,promoted:false};if(!isInCheck(PLAYER_GOTE,tempBoard)){let score=1;if(isInCheck(PLAYER_SENTE,tempBoard))score+=50;allLegalActions.push({action:'drop',pieceTypeKey:capPiece.type,toR:dr,toC:dc,score});}}}}}if(allLegalActions.length===0){console.log("AI has no legal moves!");isAiThinking=false;updatePlayerTurnDisplay();return;}allLegalActions.sort((a,b)=>b.score-a.score);const bestScore=allLegalActions[0].score;const bestMoves=allLegalActions.filter(m=>m.score===bestScore);const chosenAction=bestMoves[Math.floor(Math.random()*bestMoves.length)];console.log("AI Chose: ",chosenAction);if(chosenAction.action==='move'){const pieceToMove=board[chosenAction.fromR][chosenAction.fromC];const targetPiece=board[chosenAction.toR][chosenAction.toC];if(targetPiece){let unpromotedTypeKey=UNPROMOTED_MAP[targetPiece.type]||targetPiece.type;goteCapturedPieces.push({type:unpromotedTypeKey,originalPlayer:targetPiece.player});}board[chosenAction.fromR][chosenAction.fromC]=null;pieceToMove.promoted=chosenAction.promotion;board[chosenAction.toR][chosenAction.toC]=pieceToMove;}else if(chosenAction.action==='drop'){board[chosenAction.toR][chosenAction.toC]={type:chosenAction.pieceTypeKey,player:PLAYER_GOTE,promoted:false};const dropIdx=goteCapturedPieces.findIndex(p=>p.type===chosenAction.pieceTypeKey);if(dropIdx>-1)goteCapturedPieces.splice(dropIdx,1);}isAiThinking=false;switchPlayerAndCheckGameEnd();},500);}
-    function handleCapturedPieceClick(typeKey,owner){if(isGameOver||currentPlayer!==owner||(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE))return;if(selectedPieceForDrop&&selectedPieceForDrop.type===typeKey){selectedPieceForDrop=null;}else{selectedPieceForDrop={type:typeKey,originalPlayer:owner};selectedPiece=null;}renderCapturedPieces();updatePlayerTurnDisplay();}
-    function handleSquareClick(event){if(isGameOver||isAiThinking||(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE))return;const clickedSq=event.target.closest('.square');if(!clickedSq)return;const toR=parseInt(clickedSq.dataset.row);const toC=parseInt(clickedSq.dataset.col);if(selectedPieceForDrop){const pieceToDropKey=selectedPieceForDrop.type;if(board[toR][toC]){if(board[toR][toC].player===currentPlayer){selectedPiece={piece:board[toR][toC],fromRow:toR,fromCol:toC};selectedPieceForDrop=null;renderCapturedPieces();updatePlayerTurnDisplay();console.log(`Switched to move mode. Selected ${PIECES[selectedPiece.piece.type]}`);}else{console.log("Cannot drop onto an occupied square.");}return;}if(isValidDrop(pieceToDropKey,toR,toC,currentPlayer,board)){const tempBoard=deepCopyBoard(board);tempBoard[toR][toC]={type:pieceToDropKey,player:currentPlayer,promoted:false};if(isInCheck(currentPlayer,tempBoard)){console.log("Illegal drop: cannot put own king in check.");gameStatusMessage="Illegal: Puts King in Check";updatePlayerTurnDisplay();setTimeout(()=>{gameStatusMessage="";updatePlayerTurnDisplay();},2000);return;}board[toR][toC]=tempBoard[toR][toC];const hand=currentPlayer===PLAYER_SENTE?senteCapturedPieces:goteCapturedPieces;const idx=hand.findIndex(p=>p.type===pieceToDropKey);if(idx>-1)hand.splice(idx,1);console.log(`${currentPlayer} dropped ${PIECES[pieceToDropKey]} at (${toR},${toC})`);selectedPieceForDrop=null;switchPlayerAndCheckGameEnd();}else{console.log(`Invalid drop for ${PIECES[pieceToDropKey]} at (${toR},${toC})`);}}else if(selectedPiece){const{piece,fromRow,fromCol}=selectedPiece;if(fromRow===toR&&fromCol===toC){selectedPiece=null;console.log("Deselected.");return;}const targetPiece=board[toR][toC];if(targetPiece&&targetPiece.player===currentPlayer){selectedPiece={piece:targetPiece,fromRow:toR,fromCol:toC};console.log(`Reselected: ${PIECES[targetPiece.type]}`);return;}const validMoves=getValidMoves(piece,fromRow,fromCol,board);if(validMoves.some(([r,c])=>r===toR&&c===toC)){const tempBoard=deepCopyBoard(board);let pieceToMoveCopy={...piece};if(targetPiece&&targetPiece.player!==currentPlayer){}tempBoard[toR][toC]=pieceToMoveCopy;tempBoard[fromRow][fromCol]=null;let potentialPromotion=false;if(canPromote(pieceToMoveCopy,toR,fromRow,currentPlayer)){if(mustPromote(pieceToMoveCopy,toR,currentPlayer)||window.confirm(`Promote ${PIECES[pieceToMoveCopy.type]} to ${PIECES[PROMOTION_MAP[pieceToMoveCopy.type]] || PIECES[pieceToMoveCopy.type]}?`)){potentialPromotion=true;pieceToMoveCopy.promoted=true;}}tempBoard[toR][toC]=pieceToMoveCopy;if(isInCheck(currentPlayer,tempBoard)){console.log("Illegal move: cannot put own king in check.");gameStatusMessage="Illegal: Puts King in Check";updatePlayerTurnDisplay();setTimeout(()=>{gameStatusMessage="";updatePlayerTurnDisplay();},2000);return;}let actualMovedPiece={...piece};if(targetPiece&&targetPiece.player!==currentPlayer){const captured=targetPiece;let unpromotedTypeKey=UNPROMOTED_MAP[captured.type]||captured.type;(currentPlayer===PLAYER_SENTE?senteCapturedPieces:goteCapturedPieces).push({type:unpromotedTypeKey,originalPlayer:captured.player});console.log(`${currentPlayer} captured ${PIECES[captured.type]}`);}board[fromRow][fromCol]=null;if(canPromote(actualMovedPiece,toR,fromRow,currentPlayer)){if(mustPromote(actualMovedPiece,toR,currentPlayer)||pieceToMoveCopy.promoted){actualMovedPiece.promoted=true;console.log(`Piece ${PIECES[piece.type]} promoted.`);}}board[toR][toC]=actualMovedPiece;console.log(`${currentPlayer} moved ${PIECES[piece.type]} from (${fromRow},${fromCol}) to (${toR},${toC})`);selectedPiece=null;switchPlayerAndCheckGameEnd();}else{console.log(`Invalid move for ${PIECES[piece.type]}`);}}else{const pieceOnSq=board[toR][toC];if(pieceOnSq&&pieceOnSq.player===currentPlayer){selectedPiece={piece:pieceOnSq,fromRow:toR,fromCol:toC};selectedPieceForDrop=null;console.log(`Selected: ${PIECES[pieceOnSq.type]} at (${toR}, ${toC})`);renderCapturedPieces();updatePlayerTurnDisplay();}else if(pieceOnSq){console.log("Opponent's piece.");}else{console.log("Empty square.");}}}
-    function switchPlayerAndCheckGameEnd(){const prevPlayer=currentPlayer;currentPlayer=currentPlayer===PLAYER_SENTE?PLAYER_GOTE:PLAYER_SENTE;gameStatusMessage="";if(isCheckmate(currentPlayer,board)){gameStatusMessage=`Checkmate! ${prevPlayer} wins!`;isGameOver=true;console.log(gameStatusMessage);}else if(isInCheck(currentPlayer,board)){gameStatusMessage="Check!";console.log("Player is in Check!");}renderBoard();if(isSinglePlayerMode&&currentPlayer===PLAYER_GOTE&&!isGameOver){makeAiMove();}}
-    function addSquareClickListeners(){const squares=document.querySelectorAll('.square');squares.forEach(sq=>{sq.removeEventListener('click',handleSquareClick);sq.addEventListener('click',handleSquareClick);});}
-    newGameButton.addEventListener('click',startGame);singlePlayerCheckbox.addEventListener('change',startGame);function startGame(){console.log("New Game started");initializeBoard();}startGame();
+    function startGame(){console.log("New Game started");initializeBoard();}
+    // Initial call to set mode from checkbox state
+    isHighlightModeEnabled = highlightModeCheckbox.checked;
+    startGame();
 });
-console.log("Shogi game script (reverted to text pieces) loaded.");
+console.log("Shogi game script (with highlight toggle logic) loaded.");


### PR DESCRIPTION
This commit introduces a new feature that allows players to see the possible moves for a selected piece highlighted on the board. You can toggle this feature on or off.

Key changes:
- **CSS for Highlighting**: Added a `.valid-move-highlight` class in `shogi_game.css` to style squares that are valid destinations.
- **HTML Toggle**: Included a checkbox "Show Valid Moves (候補手表示)" in `shogi_game.html` allowing you to enable or disable this feature. It's enabled by default.
- **JavaScript Logic**:
    - Implemented `showValidMoveHighlights(piece, fromRow, fromCol)` to display highlights by adding the CSS class to valid move squares obtained from `getValidMoves()`.
    - Implemented `clearAllValidMoveHighlights()` to remove highlights from all squares.
    - Added an event listener to the toggle checkbox to update the highlighting state (`isHighlightModeEnabled`) and apply/clear highlights accordingly.
    - Integrated highlight display and clearing into existing game logic:
        - Highlights are shown when a piece is selected (if mode is enabled).
        - Highlights are cleared when a piece is deselected, a move is made, a drop is made, the mode is toggled off, or a new game starts.

This feature enhances gameplay by providing visual guidance on piece movements, especially helpful for newer players.